### PR TITLE
Unhandled std::bad_alloc exception

### DIFF
--- a/include/VariadicTable.h
+++ b/include/VariadicTable.h
@@ -276,7 +276,7 @@ protected:
     if (data == 0)
       return 1;
 
-    return std::log10(data) + 1;
+    return data < 0 ? std::log10(data * (-1)) + 1 : std::log10(data) + 1;
   }
 
   /**


### PR DESCRIPTION
The unhandled exception was getting triggered whenever there was a negative number inserted into the table. (eg. -1).

In that case, the negative number was being passed to the std::log10() function, which was returning invalid value and that was causing the problem with allocation later in the code.